### PR TITLE
fixed context for didResizeHandler.

### DIFF
--- a/addon/mixins/resize.js
+++ b/addon/mixins/resize.js
@@ -13,13 +13,13 @@ export default Mixin.create({
 
 		this._super(...arguments);
 
-		window.addEventListener('resize', this.didResizeHandler);
+		window.addEventListener('resize', this.didResizeHandler.bind(this));
 
 	},
 
 	willDestroyElement() {
 
-		window.removeEventListener('resize', this.didResizeHandler);
+		window.removeEventListener('resize', this.didResizeHandler.bind(this));
 
 		this._super(...arguments);
 


### PR DESCRIPTION
The `this` in the `this.didResizeHandler` got bound to `window` instead of the component.